### PR TITLE
Demo example of deploying dev center with terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ terraform.rc
 packer-for-image-generation/terraform/.terraform.lock.hcl
 .env
 .DS_Store
+
+tfplan
+*.tfplan

--- a/packer-for-image-generation/eclipse/eclipse.pkr.hcl
+++ b/packer-for-image-generation/eclipse/eclipse.pkr.hcl
@@ -12,8 +12,7 @@ source "azure-arm" "windows" {
   client_secret   = "${var.client_secret}"
   subscription_id = "${var.subscription_id}"
   tenant_id       = "${var.tenant_id}"
-  location        = "${var.location}"
-
+  build_resource_group_name        = "${var.build_resource_group_name}"
 
   managed_image_resource_group_name = "${var.resource_group}"
   managed_image_name                = "${var.image_name}"

--- a/packer-for-image-generation/eclipse/variables.pkr.hcl
+++ b/packer-for-image-generation/eclipse/variables.pkr.hcl
@@ -42,3 +42,7 @@ variable "image_version" {
   type    = string
   default = "1.0.0"
 }
+
+variable "build_resource_group_name" {
+  type    = string
+}

--- a/packer-for-image-generation/jetbrains/jetbrains.pkr.hcl
+++ b/packer-for-image-generation/jetbrains/jetbrains.pkr.hcl
@@ -12,8 +12,7 @@ source "azure-arm" "windows" {
   client_secret   = "${var.client_secret}"
   subscription_id = "${var.subscription_id}"
   tenant_id       = "${var.tenant_id}"
-  location        = "${var.location}"
-
+  build_resource_group_name        = "${var.build_resource_group_name}"
 
   managed_image_resource_group_name = "${var.resource_group}"
   managed_image_name                = "${var.image_name}"

--- a/packer-for-image-generation/jetbrains/variables.pkr.hcl
+++ b/packer-for-image-generation/jetbrains/variables.pkr.hcl
@@ -42,3 +42,7 @@ variable "image_version" {
   type    = string
   default = "1.0.0"
 }
+
+variable "build_resource_group_name" {
+  type    = string
+}

--- a/packer-for-image-generation/vscode/variables.pkr.hcl
+++ b/packer-for-image-generation/vscode/variables.pkr.hcl
@@ -43,3 +43,7 @@ variable "image_version" {
   type    = string
   default = "1.0.0"
 }
+
+variable "build_resource_group_name" {
+  type    = string
+}

--- a/packer-for-image-generation/vscode/vscode.pkr.hcl
+++ b/packer-for-image-generation/vscode/vscode.pkr.hcl
@@ -12,8 +12,7 @@ source "azure-arm" "windows" {
   client_secret   = "${var.client_secret}"
   subscription_id = "${var.subscription_id}"
   tenant_id       = "${var.tenant_id}"
-  location        = "${var.location}"
-
+  build_resource_group_name        = "${var.build_resource_group_name}"
 
   managed_image_resource_group_name = "${var.resource_group}"
   managed_image_name                = "${var.image_name}"

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azuread" {
+  version     = "3.0.2"
+  constraints = "3.0.2"
+  hashes = [
+    "h1:sYCyzbPpSYu2XDah8XqBUITQAfB0x4j4Twh6lw2C4CA=",
+    "zh:16e724b80a9004c7978c30f69a73c98ff63eb8a03937dd44c2a8f0ea0438b7a3",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:2bbbf13713ca4767267b889471c9fc14a56a8fdf5d1013da3ca78667e3caec64",
+    "zh:409ccb05431d643a079da082d89db2d95d6afed4769997ac537c8b7de3bff867",
+    "zh:53e4bca0f5d015380f7f524f36344afe6211ccaf614bfc69af73ca64a9f47d6c",
+    "zh:5780be2c1981d090604d7fa4cef675462f17f40e7f3dc501a031488e87a35b8f",
+    "zh:850e61a1b3e64c752c418526ccf48653514c861b36f5feb631619f906f7e99a0",
+    "zh:8c3565bfcea006a734149cc080452a9daf7d2a9d5362eb7e0a088b6c0d7f0f03",
+    "zh:908b9e6ad49d5d21173ecefc7924902047611be93bbf8e7d021aa9563358396f",
+    "zh:a2a79765c029bc58966eff61cb6e9b0ee14d2ac52b0a22fc7dfa35c9a49af669",
+    "zh:c7f56cbe8743e9ba81fce871bc97d9c07abe86770d9ee7ffefbf3882a61ba89a",
+    "zh:d4dba80e33421b30d81c62611fb7fc62ad39afecc6484436e635913cd8553e67",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.13.0"
+  constraints = "4.13.0"
+  hashes = [
+    "h1:+xwytJmaCeCNFlQ44My+geG5+1yGPzkRDGN5cvbkadI=",
+    "zh:23e04573f50cec091cb32113e3e78033b1ba00ddbc9b7aece0d6397ae60b9b5e",
+    "zh:53d07a697e5aa36561a4b11e22a68c7cb582d46ed42cd4a61c08796d38f18bc9",
+    "zh:56064e9fbd5330ba734af24aca23ed0c93b12117474ae08d8180bca0dbf3ac06",
+    "zh:791bd9a35b5e7b0d7c9c0beb617b5b9b19c511583bcb5b69e557849b3924c000",
+    "zh:8e9cfc598a21d7fcf265665c792d4abb26b61ea82b9daeae24c5c93af1109617",
+    "zh:a447ad87109103fa8b357fcee002babece379ea1125cf1b7c7c3268610f93f97",
+    "zh:b5ae53fe1f3e272fe1b3a38738264734ea9bcb9b061d17e403d60e0d0072755d",
+    "zh:c37cf35d6d1bebc7d3dd01888e9e3d49f96993ac0f928df38337a7415569c116",
+    "zh:ed02965a8dcfcecf62eaa39c721e780dfa5f568ef0b0a24cca7c47721faec223",
+    "zh:ed73066c3f1eb5e9b25b49da07593d48d466c4f23dcde49ba1058ae2145ca365",
+    "zh:f0c68566bde550f5a5a222143e9cd005a8028cd825cf1e12d13afbbd5f55db77",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/00-variables.tf
+++ b/terraform/00-variables.tf
@@ -28,5 +28,11 @@ variable "custom_images" {
       sku = "demo"
       semver = "1.0.0"
     }
+    eclipse = {
+      publisher_name = "devgbb"
+      offer_name = "eclipsebox"
+      sku = "demo"
+      semver = "1.0.0"
+    }
   }
 }

--- a/terraform/00-variables.tf
+++ b/terraform/00-variables.tf
@@ -1,0 +1,32 @@
+variable "subscription_id" {
+  description = "value of the subscription_id"
+  type = string
+}
+
+variable "resource_group_name" {
+  description = "Name of the Resource Group in which the resources should be deployed"
+  type = string
+}
+
+variable "location" {
+  description = "Azure Region in which the resources should be deployed"
+  type = string
+}
+
+variable "custom_images" {
+  description = "Name of the custom image to create"
+  type = map(object({
+    publisher_name = string
+    offer_name = string
+    sku = string
+    semver = string
+  }))
+  default = {
+    jetbrains = {
+      publisher_name = "devgbb"
+      offer_name = "jetbrainsbox"
+      sku = "demo"
+      semver = "1.0.0"
+    }
+  }
+}

--- a/terraform/10-main.tf
+++ b/terraform/10-main.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "4.13.0"
+    }
+    azuread = {
+      source = "hashicorp/azuread"
+      version = "3.0.2"
+    }
+  }
+}
+
+provider "azurerm" {
+  subscription_id = var.subscription_id
+  features {
+    
+  }
+}
+
+provider "azuread" {
+  
+}
+
+data "azurerm_client_config" "current" {
+  
+}

--- a/terraform/20-outputs.tf
+++ b/terraform/20-outputs.tf
@@ -1,0 +1,29 @@
+output client_id {
+  value=   azuread_service_principal.packer.client_id
+}
+output client_secret {
+  value=   azuread_service_principal_password.packer.value
+  sensitive = true
+}
+output subscription_id {
+  value=   var.subscription_id
+}
+output tenant_id {
+  value=   data.azurerm_client_config.current.tenant_id
+}
+output location {
+  value=   var.location
+}
+output build_resource_group_name {
+  value=   azurerm_resource_group.default.name
+}
+output resource_group {
+  value=   azurerm_resource_group.default.name
+}
+
+output gallery_resource_group {
+  value=   azurerm_resource_group.default.name
+}
+output gallery_name {
+  value=   azurerm_shared_image_gallery.default.name
+}  

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,31 @@
+# Using this Terraform
+
+## Variables
+
+1. Copy or rename the terraforms.tfvars.example file
+2. Enter the required values (e.g. ```subscription_id``` required by the ```azurerm``` provider)
+
+## Executing the command
+
+From the repo root
+
+```bash
+cd terraform
+terraform init
+terraform plan -out tfplan
+terraform apply tfplan
+```
+
+## Notes
+
+### Packer and custom images
+
+While we include a way to build a custom image in a single Terraform module using the [terraform_data](https://developer.hashicorp.com/terraform/language/resources/terraform-data) resource type and [local-exec](https://developer.hashicorp.com/terraform/language/resources/provisioners/local-exec) provisioner, this is not an ideal path to do so outside of this demo as it would be better suited to be in its own GitHub Actions Workflow or other CI/CD process to create and version the image.  Ideally custom images are in a "mono repo" that contains all custom image definitions and environments that they should deploy to, and you would need to provide the targetted::
+
+- Dev Center ID
+- Dev Center Gallery ID
+- Image Name (Same as the azurerm_shared_image.$identifier.name )
+
+### Clean up
+
+For the demo itself the easiest path is to run ```az group delete -n $RG_NAME``` instead of ```terraform destroy``` as there are dependent resources created that were generated outside of Terraform and therefore Terraform has no ability to remove these child/dependent resources.  As an example, the custom image versions created with Packer, since they were generated with the terraform_data resource as a wrapper, are technically outside of Terraforms normal resource lifecycle.

--- a/terraform/azurerm_application.tf
+++ b/terraform/azurerm_application.tf
@@ -1,0 +1,13 @@
+resource "azuread_application" "packer" {
+  display_name = "Dev Center Packer SPN"
+  owners = [data.azurerm_client_config.current.object_id]
+}
+resource "azuread_service_principal" "packer" {
+  client_id = azuread_application.packer.client_id
+  use_existing = true
+  owners = [data.azurerm_client_config.current.object_id]
+}
+
+resource "azuread_service_principal_password" "packer" {
+  service_principal_id = azuread_service_principal.packer.id
+}

--- a/terraform/azurerm_dev_center_dev_box_definition.tf
+++ b/terraform/azurerm_dev_center_dev_box_definition.tf
@@ -1,4 +1,5 @@
 resource "azurerm_dev_center_dev_box_definition" "default" {
+  depends_on = [ terraform_data.packer ]
   for_each = var.custom_images
   location           = azurerm_resource_group.default.location
   name               = "${each.key}"

--- a/terraform/azurerm_dev_center_dev_box_definition.tf
+++ b/terraform/azurerm_dev_center_dev_box_definition.tf
@@ -1,0 +1,7 @@
+resource "azurerm_dev_center_dev_box_definition" "default" {
+  location           = azurerm_resource_group.default.location
+  name               = "default-dcet"
+  dev_center_id      = module.dev-center.id
+  image_reference_id = data.azurerm_shared_image_version.custom_images["jetbrains"].id
+  sku_name           = "demo"
+}

--- a/terraform/azurerm_dev_center_dev_box_definition.tf
+++ b/terraform/azurerm_dev_center_dev_box_definition.tf
@@ -1,7 +1,8 @@
 resource "azurerm_dev_center_dev_box_definition" "default" {
+  for_each = var.custom_images
   location           = azurerm_resource_group.default.location
-  name               = "default-dcet"
+  name               = "${each.key}"
   dev_center_id      = module.dev-center.id
-  image_reference_id = data.azurerm_shared_image_version.custom_images["jetbrains"].id
-  sku_name           = "demo"
+  image_reference_id = "${module.dev-center.gallery_id}/images/${azurerm_shared_image.image_definitions[each.key].name}"
+  sku_name           = "general_i_8c32gb256ssd_v2" # The VM SKU to use for the Dev Box NOT the image SKU
 }

--- a/terraform/azurerm_dev_center_project.tf
+++ b/terraform/azurerm_dev_center_project.tf
@@ -1,0 +1,6 @@
+resource "azurerm_dev_center_project" "default" {
+  resource_group_name = azurerm_resource_group.default.name
+  location            = azurerm_resource_group.default.location
+  dev_center_id       = module.dev-center.id
+  name                = "${module.dev-center.name}-project-1"
+}

--- a/terraform/azurerm_key_vault.tf
+++ b/terraform/azurerm_key_vault.tf
@@ -1,0 +1,13 @@
+resource "azurerm_key_vault" "default" {
+  name                = "${azurerm_resource_group.default.name}-kv"
+  location            = azurerm_resource_group.default.location
+  resource_group_name = azurerm_resource_group.default.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+  enable_rbac_authorization = true
+  enabled_for_deployment = false
+  enabled_for_disk_encryption = false
+  enabled_for_template_deployment = false
+  soft_delete_retention_days = 7
+  purge_protection_enabled = false
+}

--- a/terraform/azurerm_resource_group.tf
+++ b/terraform/azurerm_resource_group.tf
@@ -1,0 +1,4 @@
+resource "azurerm_resource_group" "default" {
+  name     = var.resource_group_name
+  location = var.location
+}

--- a/terraform/azurerm_resource_group.tf
+++ b/terraform/azurerm_resource_group.tf
@@ -2,3 +2,8 @@ resource "azurerm_resource_group" "default" {
   name     = var.resource_group_name
   location = var.location
 }
+
+resource "azurerm_resource_group" "packer" {
+  name     = "${var.resource_group_name}-packer"
+  location = var.location
+}

--- a/terraform/azurerm_role_assignment.tf
+++ b/terraform/azurerm_role_assignment.tf
@@ -17,9 +17,17 @@ resource "azurerm_role_assignment" "dev-center-sig" {
 }
 
 resource "azurerm_role_assignment" "packer_rg_contributor" {
-  description = "Allow Packer to manage resources in the Dev Center Resource Group"
+  description = "Allow Packer to manage/deploy resources in the a specialized Packer build only Resource Group"
   role_definition_name = "Contributor"
   principal_type = "ServicePrincipal"
   principal_id = azuread_service_principal.packer.object_id
-  scope = azurerm_resource_group.default.id
+  scope = azurerm_resource_group.packer.id
+}
+
+resource "azurerm_role_assignment" "packer_sig_contributor" {
+  description = "Allow Packer to manage Images in Shared Images Gallery"
+  role_definition_name = "Contributor"
+  principal_type = "ServicePrincipal"
+  principal_id = azuread_service_principal.packer.object_id
+  scope = azurerm_shared_image_gallery.default.id
 }

--- a/terraform/azurerm_role_assignment.tf
+++ b/terraform/azurerm_role_assignment.tf
@@ -1,0 +1,25 @@
+resource "azurerm_role_assignment" "current-user" {
+  scope              = azurerm_key_vault.default.id
+  role_definition_name = "Key Vault Secrets Officer"
+  principal_id       = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_role_assignment" "dev-center-kv" {
+  scope              = azurerm_key_vault.default.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id       = azurerm_user_assigned_identity.dev-center.principal_id
+}
+
+resource "azurerm_role_assignment" "dev-center-sig" {
+  scope              = azurerm_shared_image_gallery.default.id
+  role_definition_name = "Contributor"
+  principal_id       = azurerm_user_assigned_identity.dev-center.principal_id
+}
+
+resource "azurerm_role_assignment" "packer_rg_contributor" {
+  description = "Allow Packer to manage resources in the Dev Center Resource Group"
+  role_definition_name = "Contributor"
+  principal_type = "ServicePrincipal"
+  principal_id = azuread_service_principal.packer.object_id
+  scope = azurerm_resource_group.default.id
+}

--- a/terraform/azurerm_role_assignment.tf
+++ b/terraform/azurerm_role_assignment.tf
@@ -16,6 +16,14 @@ resource "azurerm_role_assignment" "dev-center-sig" {
   principal_id       = azurerm_user_assigned_identity.dev-center.principal_id
 }
 
+resource "azurerm_role_assignment" "packer_dev_center_rg_contributor" {
+  description = "Allow Packer to view resources in the main Dev Center Resource Group (Used for Shared Compute Gallery)"
+  role_definition_name = "Contributor"
+  principal_type = "ServicePrincipal"
+  principal_id = azuread_service_principal.packer.object_id
+  scope = azurerm_resource_group.default.id
+}
+
 resource "azurerm_role_assignment" "packer_rg_contributor" {
   description = "Allow Packer to manage/deploy resources in the a specialized Packer build only Resource Group"
   role_definition_name = "Contributor"

--- a/terraform/azurerm_shared_image_gallery.tf
+++ b/terraform/azurerm_shared_image_gallery.tf
@@ -1,0 +1,25 @@
+resource "azurerm_shared_image_gallery" "default" {
+  name                = "dev_center_shared_image_gallery"
+  location            = azurerm_resource_group.default.location
+  resource_group_name = azurerm_resource_group.default.name
+}
+
+# Create shared image definitions for each image
+resource "azurerm_shared_image" "image_definitions" {
+  for_each            = var.custom_images
+  name                = each.key
+  gallery_name        = azurerm_shared_image_gallery.default.name
+  resource_group_name = azurerm_resource_group.default.name
+  location            = var.location
+
+  os_type = "Windows"
+
+  trusted_launch_enabled = true
+  hyper_v_generation     = "V2"
+
+  identifier {
+    publisher = each.value.publisher_name
+    offer     = each.value.offer_name
+    sku       = each.value.sku
+  }
+}

--- a/terraform/azurerm_user_assigned_identity.tf
+++ b/terraform/azurerm_user_assigned_identity.tf
@@ -1,0 +1,5 @@
+resource "azurerm_user_assigned_identity" "dev-center" {
+  resource_group_name = azurerm_resource_group.default.name
+  location            = azurerm_resource_group.default.location
+  name                = "${azurerm_resource_group.default.name}-dev-center-user-msi"
+}

--- a/terraform/azurerm_virtual_network.tf
+++ b/terraform/azurerm_virtual_network.tf
@@ -1,0 +1,13 @@
+resource "azurerm_virtual_network" "default" {
+  name = "dev-center-attached-vnet"
+  location = var.location
+  resource_group_name = azurerm_resource_group.default.name
+  address_space = ["10.10.0.0/16"]
+}
+
+resource "azurerm_subnet" "dev-center" {
+  name                 = "DevCenterAttachedSubnet"
+  resource_group_name  = azurerm_resource_group.default.name
+  virtual_network_name = azurerm_virtual_network.default.name
+  address_prefixes     = ["10.10.2.0/24"]
+}

--- a/terraform/modules.tf
+++ b/terraform/modules.tf
@@ -1,0 +1,8 @@
+module "dev-center" {
+  source = "./modules/dev-center"
+  resource_group = azurerm_resource_group.default
+  identity = azurerm_user_assigned_identity.dev-center
+  shared_gallery_id = azurerm_shared_image_gallery.default.id
+  key_vault_id = azurerm_key_vault.default.id
+  subnet-id = azurerm_subnet.dev-center.id
+}

--- a/terraform/modules/dev-center/00-variables.tf
+++ b/terraform/modules/dev-center/00-variables.tf
@@ -1,0 +1,30 @@
+variable "resource_group" {
+  description = "The Resource Group in which the Dev Center should be created"
+  type= object({
+    name = string
+    location = string
+  })
+}
+
+variable "shared_gallery_id" {
+  description = "The ID of the Shared Gallery to associate with this Dev Center"
+  type        = string
+}
+
+variable "identity" {
+  description = "The User Assigned Identity to associate with the Dev Center"
+  type        = object({
+    id = string
+    client_id = string
+  })
+}
+
+variable "key_vault_id" {
+  description = "The ID of the Key Vault to associate with this Dev Center"
+  type        = string
+}
+
+variable "subnet-id" {
+  description = "The Virtual Network to attach to the Dev Center"
+  type        = string
+}

--- a/terraform/modules/dev-center/20-outputs.tf
+++ b/terraform/modules/dev-center/20-outputs.tf
@@ -1,0 +1,8 @@
+output "id" {
+  value = azurerm_dev_center.default.id
+}
+
+output "name" {
+  value = azurerm_dev_center.default.name
+  
+}

--- a/terraform/modules/dev-center/20-outputs.tf
+++ b/terraform/modules/dev-center/20-outputs.tf
@@ -6,3 +6,7 @@ output "name" {
   value = azurerm_dev_center.default.name
   
 }
+
+output "gallery_id" {
+  value = azurerm_dev_center_gallery.default.id
+}

--- a/terraform/modules/dev-center/40-azurerm_dev_center.tf
+++ b/terraform/modules/dev-center/40-azurerm_dev_center.tf
@@ -1,0 +1,11 @@
+resource "azurerm_dev_center" "default" {
+  name                = "${var.resource_group.name}"
+  resource_group_name = var.resource_group.name
+  location            = var.resource_group.location
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      var.identity.id
+    ]
+  }
+}

--- a/terraform/modules/dev-center/azurerm_dev_center_attached_network.tf
+++ b/terraform/modules/dev-center/azurerm_dev_center_attached_network.tf
@@ -1,0 +1,5 @@
+resource "azurerm_dev_center_attached_network" "default" {
+  name                  = "default-dev-center-attached-network"
+  dev_center_id         = azurerm_dev_center.default.id
+  network_connection_id = azurerm_dev_center_network_connection.default.id
+}

--- a/terraform/modules/dev-center/azurerm_dev_center_gallery.tf
+++ b/terraform/modules/dev-center/azurerm_dev_center_gallery.tf
@@ -1,5 +1,5 @@
 resource "azurerm_dev_center_gallery" "default" {
-  name              = "gbbtest001"
+  name              = "dev-center-gallery"
   dev_center_id     = azurerm_dev_center.default.id
   shared_gallery_id = var.shared_gallery_id
 }

--- a/terraform/modules/dev-center/azurerm_dev_center_gallery.tf
+++ b/terraform/modules/dev-center/azurerm_dev_center_gallery.tf
@@ -1,0 +1,5 @@
+resource "azurerm_dev_center_gallery" "default" {
+  name              = "gbbtest001"
+  dev_center_id     = azurerm_dev_center.default.id
+  shared_gallery_id = var.shared_gallery_id
+}

--- a/terraform/modules/dev-center/azurerm_dev_center_gallery.tf
+++ b/terraform/modules/dev-center/azurerm_dev_center_gallery.tf
@@ -1,5 +1,5 @@
 resource "azurerm_dev_center_gallery" "default" {
-  name              = "dev-center-gallery"
+  name              = "devcentergallery"
   dev_center_id     = azurerm_dev_center.default.id
   shared_gallery_id = var.shared_gallery_id
 }

--- a/terraform/modules/dev-center/azurerm_dev_center_network_connection.tf
+++ b/terraform/modules/dev-center/azurerm_dev_center_network_connection.tf
@@ -1,0 +1,7 @@
+resource "azurerm_dev_center_network_connection" "default" {
+  name                = "default-dev-center-network-connection"
+  resource_group_name = var.resource_group.name
+  location            = var.resource_group.location
+  domain_join_type    = "AzureADJoin"
+  subnet_id           = var.subnet-id
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,3 @@
+subscription_id = "00000000-0000-0000-0000-000000000000"
+resource_group_name = "gbb-dev-center"
+location = "westeurope"

--- a/terraform/terraform_data.tf
+++ b/terraform/terraform_data.tf
@@ -1,6 +1,6 @@
 resource "terraform_data" "packer" {
   for_each = var.custom_images
-  input = each.value
+  input = var.custom_images
 
   provisioner "local-exec" {
     working_dir = "${path.module}/../packer-for-image-generation/${each.key}"

--- a/terraform/terraform_data.tf
+++ b/terraform/terraform_data.tf
@@ -1,4 +1,9 @@
 resource "terraform_data" "packer" {
+  depends_on = [ 
+    azurerm_role_assignment.packer_rg_contributor,
+    azurerm_role_assignment.packer_dev_center_rg_contributor,
+    azurerm_role_assignment.packer_shared_image_gallery_contributor
+  ]
   for_each = var.custom_images
   input = var.custom_images
 

--- a/terraform/terraform_data.tf
+++ b/terraform/terraform_data.tf
@@ -1,0 +1,34 @@
+resource "terraform_data" "packer" {
+  for_each = var.custom_images
+  input = each.value
+
+  provisioner "local-exec" {
+    working_dir = "${path.module}/../packer-for-image-generation/${each.key}"
+    command = <<EOT
+      packer init .
+      
+      packer build -force \
+      -var client_id=${azuread_service_principal.packer.client_id} \
+      -var client_secret=${azuread_service_principal_password.packer.value} \
+      -var subscription_id=${var.subscription_id} \
+      -var tenant_id=${data.azurerm_client_config.current.tenant_id} \
+      -var location=${var.location} \
+      -var build_resource_group_name=${azurerm_resource_group.packer.name} \
+      -var resource_group=${azurerm_resource_group.default.name} \
+      -var image_name=${each.key} \
+      -var gallery_resource_group=${azurerm_resource_group.default.name} \
+      -var gallery_name=${azurerm_shared_image_gallery.default.name} \
+      -var image_version=${each.value.semver}  \
+      .
+    EOT
+  }
+}
+
+data "azurerm_shared_image_version" "custom_images" {
+  depends_on = [ terraform_data.packer ]
+  for_each = var.custom_images
+  image_name = each.key
+  name = each.value.semver
+  gallery_name = azurerm_shared_image_gallery.default.name
+  resource_group_name = azurerm_resource_group.default.name
+}

--- a/terraform/terraform_data.tf
+++ b/terraform/terraform_data.tf
@@ -2,7 +2,7 @@ resource "terraform_data" "packer" {
   depends_on = [ 
     azurerm_role_assignment.packer_rg_contributor,
     azurerm_role_assignment.packer_dev_center_rg_contributor,
-    azurerm_role_assignment.packer_shared_image_gallery_contributor
+    azurerm_role_assignment.packer_sig_contributor
   ]
   for_each = var.custom_images
   input = var.custom_images


### PR DESCRIPTION
This pull request introduces several updates to the infrastructure configuration files to enhance the deployment and management of resources to deploy an Azure Dev Center. 

The changes primarily focus on adding the basics required to:
- deploy a Dev Center instance into Azure and attach it to a VNET
- ensuring that we can create a Packer Image to an Azure Shared Compute Gallery (aka Shared Image Gallery) which is associated to the Dev Center
- have some outputted values to test Packer manually
- scoping Packer to a resource group to build it's temporary resources to (RBAC to a Packer specific RG)
- prepare an azure key vault to provide credentials to a GitHub Repo for Dev Center Catalog Access (Catalog resource not yet implemented)
- Ensure Shared Image Gallery and Image Definitions are created

TODO:
- Manual testing of Packer succeeds as expected, However:
  - Wrapping the packer command inside of a local-exec seems to take over 1hr to create (if it even succeeds) where manual testing completes in less than 30mins
  - Need to fix this issue or to diagnose why terraform running the command takes longer than expected
- Create Catalog for Dev Center
  - Requires storing a GitHub PAT token into the Azure Key Vault created